### PR TITLE
Adds ability to cache responses from PhantomJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.34",
+    "cache-client": "0.0.22",
     "phridge": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It's not super practical to use PhantomJS to render every page. It's performance
implications are just to great to do in production. This commit helps the issue
somewhat by adding a caching layer in front of phantom rendering. The cache is
keyed by the post-transform URL.

To enable caching, pass in a config object compatible with
[cache-client](https://www.npmjs.com/package/cache-client).
